### PR TITLE
Fix port number with daemonization

### DIFF
--- a/lib/whipped-cream/server.rb
+++ b/lib/whipped-cream/server.rb
@@ -39,7 +39,7 @@ module WhippedCream
     end
 
     def start_web(options = {})
-      options = options.merge({ app: web, port: port })
+      options = { app: web, port: port }.merge(options)
 
       Rack::Server.start options
     end


### PR DESCRIPTION
Thor options hash is actually a HashWithIndifferentAccess, and calling #merge
on it creates a hash with string keys, which Rack::Server does not accept

[fix #20]
