### PR TITLE
Camera support

### DIFF
--- a/demo.rb
+++ b/demo.rb
@@ -1,5 +1,7 @@
 name "Demo"
 
+camera
+
 button "Open/Close", pin: 1
 
 sensor "Door", pin: 2, high: "Open", low: "Closed"

--- a/lib/whipped-cream.rb
+++ b/lib/whipped-cream.rb
@@ -1,5 +1,6 @@
 require 'whipped-cream/builder'
 require 'whipped-cream/button'
+require 'whipped-cream/camera'
 require 'whipped-cream/cli'
 require 'whipped-cream/deployer'
 require 'whipped-cream/plugin'

--- a/lib/whipped-cream/builder.rb
+++ b/lib/whipped-cream/builder.rb
@@ -42,7 +42,7 @@ module WhippedCream
     end
 
     def camera
-      plugin.camera = true
+      plugin.controls << Camera.new
     end
 
     def helpers(&block)

--- a/lib/whipped-cream/camera.rb
+++ b/lib/whipped-cream/camera.rb
@@ -1,0 +1,9 @@
+require 'whipped-cream/control'
+
+module WhippedCream
+  # A Camera represents and iframe that points to a running video server on the
+  # Pi
+  class Camera < WhippedCream::Control
+  end
+end
+

--- a/lib/whipped-cream/deployer.rb
+++ b/lib/whipped-cream/deployer.rb
@@ -53,6 +53,16 @@ module WhippedCream
       ssh_exec 'sudo pkill -9 -f whipped-cream'
     end
 
+    def configure_camera
+      scp_copy file('motion.conf'), '/etc/motion/motion.conf'
+    end
+
+    def start_camera
+      ssh_exec <<-SCRIPT
+        sudo motion
+      SCRIPT
+    end
+
     def run_plugin
       ssh_exec <<-SCRIPT
         cd ~/whipped-cream

--- a/lib/whipped-cream/plugin.rb
+++ b/lib/whipped-cream/plugin.rb
@@ -23,6 +23,10 @@ module WhippedCream
       controls.select { |control| control.is_a? Button }
     end
 
+    def cameras
+      controls.select { |control| control.is_a? Camera }
+    end
+
     def fields
       controls.select { |control| control.is_a? Field }
     end

--- a/lib/whipped-cream/public/assets/stylesheets/application.css
+++ b/lib/whipped-cream/public/assets/stylesheets/application.css
@@ -20,6 +20,10 @@ time, mark, audio, video {
   vertical-align: baseline;
 }
 
+iframe {
+  width: 100%
+}
+
 /* line 22, ../../../../../../../../.rvm/gems/ruby-1.9.3-p194/gems/compass-0.12.2/frameworks/compass/stylesheets/compass/reset/_utilities.scss */
 html {
   line-height: 1;

--- a/lib/whipped-cream/views/camera.erb
+++ b/lib/whipped-cream/views/camera.erb
@@ -1,0 +1,1 @@
+<iframe src="http://localhost:18081"></iframe>

--- a/spec/lib/whipped-cream/builder_spec.rb
+++ b/spec/lib/whipped-cream/builder_spec.rb
@@ -66,9 +66,9 @@ describe WhippedCream::Builder do
   end
 
   describe "#camera" do
-    subject { plugin.camera }
+    subject { plugin.cameras }
 
-    it { should be_false }
+    it { should be_empty }
 
     context "with camera in the plugin" do
       let(:plugin) {
@@ -77,7 +77,7 @@ describe WhippedCream::Builder do
         end
       }
 
-      it { should be_true }
+      it { should_not be_empty }
     end
   end
 

--- a/spec/lib/whipped-cream/plugin_spec.rb
+++ b/spec/lib/whipped-cream/plugin_spec.rb
@@ -9,6 +9,7 @@ describe WhippedCream::Plugin do
   its(:controls) { should be_empty }
 
   its(:buttons) { should be_empty }
+  its(:cameras) { should be_empty }
   its(:fields) { should be_empty }
   its(:sensors) { should be_empty }
   its(:switches) { should be_empty }


### PR DESCRIPTION
- [x] Declare camera in plugin
- [x] Install and run motion only if camera is in plugin
- [ ] Configure motion to run as daemon
- [ ] Configure motion to allow non-localhost connections
- [x] Create camera partial
