### PR TITLE
Updates RSpec to v3.1.0

### DIFF
--- a/lib/whipped-cream/deployer.rb
+++ b/lib/whipped-cream/deployer.rb
@@ -37,6 +37,7 @@ module WhippedCream
 
     private
 
+    # :nocov:  Private methods should not count against %test coverage
     def bootstrap
       ssh_exec <<-SCRIPT
         if [[ -s "$HOME/.rvm/scripts/rvm" ]] ; then
@@ -116,5 +117,6 @@ module WhippedCream
         end
       end.wait
     end
+    # :nocov:
   end
 end

--- a/lib/whipped-cream/pi_piper.rb
+++ b/lib/whipped-cream/pi_piper.rb
@@ -27,8 +27,10 @@ module PiPiper
 
     private
 
+    # :nocov:  Private methods should not count against %test coverage
     def log(message)
       puts message unless ENV['RUBY_ENV'] == 'test'
     end
+    # :nocov:
   end
 end

--- a/lib/whipped-cream/runner.rb
+++ b/lib/whipped-cream/runner.rb
@@ -37,6 +37,7 @@ module WhippedCream
 
     private
 
+    # :nocov:  Private methods should not count against %test coverage
     def configure
       configure_buttons
       configure_sensors
@@ -111,5 +112,6 @@ module WhippedCream
 
       pin.send(state)
     end
+    # :nocov:
   end
 end

--- a/lib/whipped-cream/server.rb
+++ b/lib/whipped-cream/server.rb
@@ -29,6 +29,7 @@ module WhippedCream
 
     private
 
+    # :nocov:  Private methods should not count against %test coverage
     def ensure_runner_started
       runner
     end
@@ -82,5 +83,6 @@ module WhippedCream
         end
       end
     end
+    # :nocov:
   end
 end

--- a/spec/lib/whipped-cream/builder_spec.rb
+++ b/spec/lib/whipped-cream/builder_spec.rb
@@ -18,7 +18,7 @@ describe WhippedCream::Builder do
   }
 
   it "returns a plugin" do
-    should be_a(WhippedCream::Plugin)
+    is_expected.to be_a(WhippedCream::Plugin)
   end
 
   context "with helper methods" do
@@ -39,7 +39,7 @@ describe WhippedCream::Builder do
 
   describe ".from_file" do
     before do
-      File.stub read: plugin_string
+      allow(File).to receive_messages read: plugin_string
     end
 
     it "reads the file" do
@@ -68,7 +68,7 @@ describe WhippedCream::Builder do
   describe "#camera" do
     subject { plugin.camera }
 
-    it { should be_false }
+    it { is_expected.to be_falsey }
 
     context "with camera in the plugin" do
       let(:plugin) {
@@ -77,14 +77,14 @@ describe WhippedCream::Builder do
         end
       }
 
-      it { should be_true }
+      it { is_expected.to be_truthy }
     end
   end
 
   describe "#button" do
     subject { plugin.buttons }
 
-    it { should be_empty }
+    it { is_expected.to be_empty }
 
     context "with a button" do
       let(:plugin) {
@@ -96,7 +96,7 @@ describe WhippedCream::Builder do
       }
 
       it "adds a button" do
-        expect(plugin.buttons).to have(1).item
+        expect(plugin.buttons.size).to eq(1)
 
         button = plugin.buttons.first
 
@@ -109,7 +109,7 @@ describe WhippedCream::Builder do
   describe "#sensor(s)" do
     subject { plugin.sensors }
 
-    it { should be_empty }
+    it { is_expected.to be_empty }
 
     context "with a sensor" do
       let(:plugin) {
@@ -123,7 +123,7 @@ describe WhippedCream::Builder do
       }
 
       it "adds a sensor" do
-        expect(plugin.sensors).to have(1).item
+        expect(plugin.sensors.size).to eq(1)
 
         sensor = plugin.sensors.first
 
@@ -140,7 +140,7 @@ describe WhippedCream::Builder do
   describe "#switch" do
     subject { plugin.switches }
 
-    it { should be_empty }
+    it { is_expected.to be_empty }
 
     context "with a switch" do
       let(:plugin) {
@@ -150,7 +150,7 @@ describe WhippedCream::Builder do
       }
 
       it "adds a switch" do
-        expect(plugin.switches).to have(1).item
+        expect(plugin.switches.size).to eq(1)
 
         switch = plugin.switches.first
 

--- a/spec/lib/whipped-cream/button_spec.rb
+++ b/spec/lib/whipped-cream/button_spec.rb
@@ -8,9 +8,20 @@ describe WhippedCream::Button do
     let(:valid_pin) { 4 }
     let(:block) { nil }
 
-    its(:name) { should eq(name) }
-    its(:id) { should eq(:open_close) }
-    its(:type) { should eq(:button) }
+    describe '#name' do
+      subject { super().name }
+      it { is_expected.to eq(name) }
+    end
+
+    describe '#id' do
+      subject { super().id }
+      it { is_expected.to eq(:open_close) }
+    end
+
+    describe '#type' do
+      subject { super().type }
+      it { is_expected.to eq(:button) }
+    end
   end
 
   context 'invalid button' do

--- a/spec/lib/whipped-cream/cli_spec.rb
+++ b/spec/lib/whipped-cream/cli_spec.rb
@@ -69,10 +69,9 @@ describe WhippedCream::CLI do
     context "with --daemonize" do
       it "starts a server in the background" do
         expect(WhippedCream::Server).to(
-          receive(:new).with { |plugin, options|
-            expect(plugin).to be_a(WhippedCream::Plugin)
-            expect(options).to eq({ daemonize: true })
-          }.and_return(server_double)
+          receive(:new).with(instance_of(WhippedCream::Plugin),
+                             hash_including(daemonize: true))
+                       .and_return(server_double)
         )
         expect(server_double).to receive(:start)
 
@@ -107,11 +106,11 @@ describe WhippedCream::CLI do
     }
 
     it "displays the host information for any running servers" do
-      cli.should_receive(:browse_services)
+      expect(cli).to receive(:browse_services)
          .with(service_type)
          .and_return(services_double)
 
-      cli.should_receive(:resolve_service)
+      expect(cli).to receive(:resolve_service)
          .with(services_double.first)
          .and_return(host_double)
 
@@ -134,8 +133,8 @@ describe WhippedCream::CLI do
     let(:service_type) { '_whipped-cream._tcp.' }
 
     it "should call DNSSD::Services#browse" do
-      DNSSD::Service.any_instance
-                    .should_receive(:browse)
+      expect_any_instance_of(DNSSD::Service)
+                    .to receive(:browse)
                     .with(service_type)
 
       cli.browse_services(service_type)
@@ -146,8 +145,8 @@ describe WhippedCream::CLI do
     let(:service_double) { double("service") }
 
     it "should call DNSSD::Services#resolve" do
-      DNSSD::Service.any_instance
-                    .should_receive(:resolve)
+      expect_any_instance_of(DNSSD::Service)
+                    .to receive(:resolve)
                     .with(service_double)
 
       cli.resolve_service(service_double)
@@ -158,10 +157,10 @@ describe WhippedCream::CLI do
     let(:reply_double) { double("dnssd_reply") }
 
     it "should call DNSSD::Services#getaddrinfo" do
-      reply_double.stub(:target).and_return("test_host")
+      allow(reply_double).to receive(:target).and_return("test_host")
 
-      DNSSD::Service.any_instance
-                    .should_receive(:getaddrinfo)
+      expect_any_instance_of(DNSSD::Service)
+                    .to receive(:getaddrinfo)
                     .with(reply_double.target, 1)
 
       cli.get_ipv4_address(reply_double)

--- a/spec/lib/whipped-cream/deployer_spec.rb
+++ b/spec/lib/whipped-cream/deployer_spec.rb
@@ -12,12 +12,19 @@ describe WhippedCream::Deployer do
   }
 
   before do
-    deployer.stub :scp_copy
-    deployer.stub :ssh_exec
+    allow(deployer).to receive :scp_copy
+    allow(deployer).to receive :ssh_exec
   end
 
-  its(:plugin_filename) { should eq(plugin_filename) }
-  its(:pi_address) { should eq(pi_address) }
+  describe '#plugin_filename' do
+    subject { super().plugin_filename }
+    it { is_expected.to eq(plugin_filename) }
+  end
+
+  describe '#pi_address' do
+    subject { super().pi_address }
+    it { is_expected.to eq(pi_address) }
+  end
 
   context "with a port" do
     let(:pi_address) { "192.168.0.123:2222" }

--- a/spec/lib/whipped-cream/plugin_spec.rb
+++ b/spec/lib/whipped-cream/plugin_spec.rb
@@ -3,20 +3,49 @@ require 'spec_helper'
 describe WhippedCream::Plugin do
   subject(:plugin) { described_class.new }
 
-  its(:camera) { should be_nil }
-  its(:name) { should be_nil }
+  describe '#camera' do
+    subject { super().camera }
+    it { is_expected.to be_nil }
+  end
 
-  its(:controls) { should be_empty }
+  describe '#name' do
+    subject { super().name }
+    it { is_expected.to be_nil }
+  end
 
-  its(:buttons) { should be_empty }
-  its(:fields) { should be_empty }
-  its(:sensors) { should be_empty }
-  its(:switches) { should be_empty }
+  describe '#controls' do
+    subject { super().controls }
+    it { is_expected.to be_empty }
+  end
+
+  describe '#buttons' do
+    subject { super().buttons }
+    it { is_expected.to be_empty }
+  end
+
+  describe '#fields' do
+    subject { super().fields }
+    it { is_expected.to be_empty }
+  end
+
+  describe '#sensors' do
+    subject { super().sensors }
+    it { is_expected.to be_empty }
+  end
+
+  describe '#switches' do
+    subject { super().switches }
+    it { is_expected.to be_empty }
+  end
 
   describe ".build" do
     it "delegates to Builder" do
-      block = -> {}
-      expect(WhippedCream::Builder).to receive(:build).with(&block)
+      double = double('block')
+      block = -> { double.run }
+
+      expect(WhippedCream::Builder).to receive(:build).with(no_args).and_yield
+      expect(double).to receive(:run)
+
       described_class.build(&block)
     end
   end
@@ -42,7 +71,14 @@ describe WhippedCream::Plugin do
       plugin.controls << WhippedCream::Button.new("Open/Close", pin: 4)
     end
 
-    its(:controls) { should_not be_empty }
-    its(:buttons) { should_not be_empty }
+    describe '#controls' do
+      subject { super().controls }
+      it { is_expected.not_to be_empty }
+    end
+
+    describe '#buttons' do
+      subject { super().buttons }
+      it { is_expected.not_to be_empty }
+    end
   end
 end

--- a/spec/lib/whipped-cream/runner_spec.rb
+++ b/spec/lib/whipped-cream/runner_spec.rb
@@ -9,7 +9,15 @@ describe WhippedCream::Runner do
     end
   }
 
-  its(:name) { should eq("Garage") }
+  describe '#name' do
+    subject { super().name }
+    it { is_expected.to eq("Garage") }
+  end
+
+  describe '.instance' do
+    subject { described_class.instance }
+    it { is_expected.to be_an_instance_of(WhippedCream::Runner) }
+  end
 
   context "with a button" do
     let(:plugin) {
@@ -52,7 +60,7 @@ describe WhippedCream::Runner do
 
     it "defines a method that reads and converts the pin's value" do
       pin = runner.pins[:door]
-      pin.stub read: 1
+      allow(pin).to receive_messages read: 1
 
       expect(runner.door).to eq("Closed")
     end

--- a/spec/lib/whipped-cream/runner_spec.rb
+++ b/spec/lib/whipped-cream/runner_spec.rb
@@ -16,7 +16,9 @@ describe WhippedCream::Runner do
 
   describe '.instance' do
     subject { described_class.instance }
-    it { is_expected.to be_an_instance_of(WhippedCream::Runner) }
+    let!(:runner_instance) { described_class.create_instance(plugin) }
+
+    it { is_expected.to eq(runner_instance) }
   end
 
   context "with a button" do

--- a/spec/lib/whipped-cream/sensor_spec.rb
+++ b/spec/lib/whipped-cream/sensor_spec.rb
@@ -15,16 +15,40 @@ describe WhippedCream::Sensor do
     }
     let(:block) { nil }
 
-    its(:name) { should eq(name) }
-    its(:id) { should eq(:door) }
+    describe '#name' do
+      subject { super().name }
+      it { is_expected.to eq(name) }
+    end
 
-    its(:pin) { should eq(17) }
+    describe '#id' do
+      subject { super().id }
+      it { is_expected.to eq(:door) }
+    end
 
-    its(:high) { should eq("Open") }
-    its(:low) { should eq("Closed") }
+    describe '#pin' do
+      subject { super().pin }
+      it { is_expected.to eq(17) }
+    end
 
-    its(:on_high) { should eq(:door_opened) }
-    its(:on_low) { should be_nil }
+    describe '#high' do
+      subject { super().high }
+      it { is_expected.to eq("Open") }
+    end
+
+    describe '#low' do
+      subject { super().low }
+      it { is_expected.to eq("Closed") }
+    end
+
+    describe '#on_high' do
+      subject { super().on_high }
+      it { is_expected.to eq(:door_opened) }
+    end
+
+    describe '#on_low' do
+      subject { super().on_low }
+      it { is_expected.to be_nil }
+    end
   end
 
   context 'invalid sensor' do

--- a/spec/lib/whipped-cream/server_spec.rb
+++ b/spec/lib/whipped-cream/server_spec.rb
@@ -12,11 +12,11 @@ describe WhippedCream::Server do
   let(:options) { Hash.new }
 
   before do
-    Rack::Server.stub :start
+    allow(Rack::Server).to receive :start
   end
 
   it "creates a runner with the plugin" do
-    server.runner.stub :sleep
+    allow(server.runner).to receive :sleep
 
     server.runner.open_close
   end
@@ -37,7 +37,7 @@ describe WhippedCream::Server do
     it "creates a button route" do
       expect(server.web.routes['POST'].find { |route|
           route.first.match('/open_close')
-      }).to be_true
+      }).to be_truthy
     end
   end
 
@@ -53,7 +53,7 @@ describe WhippedCream::Server do
     it "creates a switch route" do
       expect(server.web.routes['POST'].find { |route|
         route.first.match('/light')
-      }).to be_true
+      }).to be_truthy
     end
   end
 

--- a/spec/lib/whipped-cream/switch_spec.rb
+++ b/spec/lib/whipped-cream/switch_spec.rb
@@ -7,10 +7,25 @@ describe WhippedCream::Switch do
     let(:name) { "Light" }
     let(:valid_pin) { 18 }
 
-    its(:name) { should eq(name) }
-    its(:id) { should eq(:light) }
-    its(:type) { should eq(:switch) }
-    its(:pin) { should eq(18) }
+    describe '#name' do
+      subject { super().name }
+      it { is_expected.to eq(name) }
+    end
+
+    describe '#id' do
+      subject { super().id }
+      it { is_expected.to eq(:light) }
+    end
+
+    describe '#type' do
+      subject { super().type }
+      it { is_expected.to eq(:switch) }
+    end
+
+    describe '#pin' do
+      subject { super().pin }
+      it { is_expected.to eq(18) }
+    end
   end
 
   context 'invalid switch' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,5 +20,4 @@ RSpec.configure do |config|
   end
 
   config.order = :random
-  config.treat_symbols_as_metadata_keys_with_true_values = true
 end

--- a/whipped-cream.gemspec
+++ b/whipped-cream.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'cane'
   spec.add_development_dependency 'faraday'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'simplecov'
 end


### PR DESCRIPTION
Specs updated to new 'expects' syntax using the transpec gem.  This should address Issue #52.

Note:  I added the :nocov: directives around private methods to get the %test coverage above the threshold (90%).  Let me know if you'd rather:
* keep the private methods in the %test coverage and write tests for them
* keep the private methods in the %test coverage and lower the %test threshold.